### PR TITLE
Add library image for registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build a minimal distribution container
+
+FROM ubuntu:14.04
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates librados2 apache2-utils && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY ./registry/registry /bin/registry
+COPY ./registry/config-example.yml /etc/docker/registry/config.yml
+
+VOLUME ["/var/lib/registry"]
+EXPOSE 5000
+ENTRYPOINT ["/bin/registry"]
+CMD ["/etc/docker/registry/config.yml"]

--- a/registry/config-example.yml
+++ b/registry/config-example.yml
@@ -1,0 +1,11 @@
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+    cache:
+        layerinfo: inmemory
+    filesystem:
+        rootdirectory: /var/lib/registry
+http:
+    addr: :5000

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -eq 0 ] ; then
+	echo "Usage: ./update.sh <docker/distribution tag or branch>"
+	exit
+fi
+
+VERSION=$1
+
+# cd to the current directory so the script can be run from anywhere.
+cd `dirname $0`
+
+echo "Fetching and building distribution $VERSION..."
+
+# Create a temporary directory.
+TEMP=`mktemp -d /$TMPDIR/distribution.XXXXXX`
+
+git clone -b $VERSION https://github.com/docker/distribution.git $TEMP
+docker build -t distribution-builder $TEMP
+
+# Create a dummy distribution-build container so we can run a cp against it.
+ID=$(docker create distribution-builder)
+
+# Update the local binary and config.
+docker cp $ID:/go/bin/registry registry
+docker cp $ID:/go/src/github.com/docker/distribution/cmd/registry/config-example.yml registry
+
+# Cleanup.
+docker rm -f $ID
+docker rmi distribution-builder
+
+echo "Done."


### PR DESCRIPTION
This is based on swarm-library-image.

Unfortunately, the registry binary needs to be checked in - otherwise
"docker build" wouldn't work without preparation, as is required of
official images. The binary checked in here is from distribution's
current master branch (01e6dde2fd68aaf0a8b8183ab4df11fc07e6f180). It
will need to be updated to the release version after each release.

Rather than creating a container from scratch, this library image is
based on the ubuntu container, because registry is a dynamically linked
binary.

Because we're using the ubuntu container as a base, manual installation
of ca-certificates.crt isn't necessary. If we end up switching to a
scratch container, this will need to be re-added.

@docker/distribution-maintainers