### PR TITLE
Update registry binary to version v2.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ COPY ./registry/config-example.yml /etc/docker/registry/config.yml
 VOLUME ["/var/lib/registry"]
 EXPOSE 5000
 ENTRYPOINT ["/bin/registry"]
-CMD ["/etc/docker/registry/config.yml"]
+CMD ["serve", "/etc/docker/registry/config.yml"]


### PR DESCRIPTION
Update registry binary to version v2.4.0

Add 'serve' to Dockerfile cmd.

Signed-off-by: Richard Scothern <richard.scothern@docker.com>