### PR TITLE
Add serve into the entrypoint to retain backward compatibility so the…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ COPY ./registry/config-example.yml /etc/docker/registry/config.yml
 
 VOLUME ["/var/lib/registry"]
 EXPOSE 5000
-ENTRYPOINT ["/bin/registry"]
-CMD ["serve", "/etc/docker/registry/config.yml"]
+ENTRYPOINT ["/bin/registry", "serve"]
+CMD ["/etc/docker/registry/config.yml"]


### PR DESCRIPTION
… registry can be run as so:
docker run --rm --volume /etc/docker-registry.conf:/etc/docker-registry.conf \
registry:2 /etc/docker-registry.conf

See:
https://github.com/docker/distribution/issues/1631

Signed-off-by: Richard Scothern <richard.scothern@gmail.com>