### PR TITLE
Add a startup script (docker-entrypoint.sh) and use it as the entrypo…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,7 @@ COPY ./registry/config-example.yml /etc/docker/registry/config.yml
 VOLUME ["/var/lib/registry"]
 EXPOSE 5000
 
-ENTRYPOINT ["/bin/registry"]
-CMD ["serve", "/etc/docker/registry/config.yml"]
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["/etc/docker/registry/config.yml"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+if [ -f $1 ]; then
+    set -- /bin/registry serve "$@"
+    exec "$@"
+fi
+
+if [ "$1" = "sh" ]; then
+    shift
+    set -- /bin/sh "$@"
+    exec "$@"
+fi
+
+set -- /bin/registry "$@"
+
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,17 +2,9 @@
 
 set -e
 
-if [ -f $1 ]; then
-    set -- /bin/registry serve "$@"
-    exec "$@"
-fi
-
-if [ "$1" = "sh" ]; then
-    shift
-    set -- /bin/sh "$@"
-    exec "$@"
-fi
-
-set -- /bin/registry "$@"
+case "$1" in
+    *.yaml|*.yml) set -- registry serve "$@" ;;
+    serve|garbage-collect|help|-*) set -- registry "$@" ;;
+esac
 
 exec "$@"


### PR DESCRIPTION
…int for the

official image container.

This conforms to the official image rules to run the container with a shell
without using the --entrypoint flags.

Supports:

[o] docker run registry sh                        # /bin/sh
[o] docker run -v /a:/b registry /b/config.yml    # /bin/registry serve /b/config.yml
[o] docker run registry                           # /bin/registry serve /etc/docker/config.yml
[o] docker run -ti registry -h                    # /bin/registry -h
[o] docker run <command> [args]                   # /bin/registry <command> [args]

Signed-off-by: Richard Scothern <richard.scothern@docker.com>