### PR TITLE
Update registry binary to v2.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ COPY ./registry/config-example.yml /etc/docker/registry/config.yml
 
 VOLUME ["/var/lib/registry"]
 EXPOSE 5000
-ENTRYPOINT ["/bin/registry", "serve"]
-CMD ["/etc/docker/registry/config.yml"]
+
+ENTRYPOINT ["/bin/registry"]
+CMD ["serve", "/etc/docker/registry/config.yml"]


### PR DESCRIPTION
Update registry binary to v2.4.1

Also revert 740a307b which will be superseded by an init script in the next minor release.

Signed-off-by: Richard Scothern <richard.scothern@docker.com>