### PR TITLE
Security fix: Update alpine base image to 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build a minimal distribution container
 
-FROM alpine:3.4
+FROM alpine:3.6
 
 RUN set -ex \
     && apk add --no-cache ca-certificates apache2-utils


### PR DESCRIPTION
The currently used alpine 3.4 base image has a known CVS/vulnerability.

Security fix for at least [CVE-2016-8859](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-8859) (see [Scan result for registry:2.6.2](https://hub.docker.com/r/library/registry/tags/2.6.2/))

See Issue: https://github.com/docker/distribution-library-image/pull/62