### PR TITLE
Fix security issues: bump alpine to 3.11, remove apache2-utils

### DIFF
--- a/Dockerfile.noarch
+++ b/Dockerfile.noarch
@@ -1,9 +1,9 @@
 # Build a minimal distribution container
 
-FROM alpine:3.8
+FROM alpine:3.11
 
 RUN set -ex \
-    && apk add --no-cache ca-certificates apache2-utils
+    && apk add --no-cache ca-certificates
 
 COPY ./registry /bin/registry
 COPY ./config-example.yml /etc/docker/registry/config.yml

--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -1,9 +1,9 @@
 # Build a minimal distribution container
 
-FROM alpine:3.8
+FROM alpine:3.11
 
 RUN set -ex \
-    && apk add --no-cache ca-certificates apache2-utils
+    && apk add --no-cache ca-certificates
 
 COPY ./registry /bin/registry
 COPY ./config-example.yml /etc/docker/registry/config.yml

--- a/arm/Dockerfile
+++ b/arm/Dockerfile
@@ -1,9 +1,9 @@
 # Build a minimal distribution container
 
-FROM alpine:3.8
+FROM alpine:3.11
 
 RUN set -ex \
-    && apk add --no-cache ca-certificates apache2-utils
+    && apk add --no-cache ca-certificates
 
 COPY ./registry /bin/registry
 COPY ./config-example.yml /etc/docker/registry/config.yml

--- a/arm64/Dockerfile
+++ b/arm64/Dockerfile
@@ -1,9 +1,9 @@
 # Build a minimal distribution container
 
-FROM alpine:3.8
+FROM alpine:3.11
 
 RUN set -ex \
-    && apk add --no-cache ca-certificates apache2-utils
+    && apk add --no-cache ca-certificates
 
 COPY ./registry /bin/registry
 COPY ./config-example.yml /etc/docker/registry/config.yml


### PR DESCRIPTION
```
clair-scanner --ip=192.168.1.199 registry-sec:latest

2019/07/29 22:03:26 [INFO] ▶ Start clair-scanner
2019/07/29 22:03:27 [INFO] ▶ Server listening on port 9279
2019/07/29 22:03:27 [INFO] ▶ Analyzing 71dfcdef6f6a027f6bffba7af1f1e2b492f442044628d9d0412b8e12d1753a8e
2019/07/29 22:03:27 [INFO] ▶ Analyzing 73459a4b5c3a721fded9b86c1bbb625bfd0377cbaa1210af4250ef8f5b4421bd
2019/07/29 22:03:27 [INFO] ▶ Analyzing 5ad54602b51de7f5954b6019f09915f1f306fc1b8f5f3f9ad8ca9da8f9f9c52b
2019/07/29 22:03:27 [INFO] ▶ Analyzing 8d3aa8b0df87b6ed1192384b5bb3ea24cd7f9befde9bc01aa3faf5c6a64a2334
2019/07/29 22:03:27 [INFO] ▶ Analyzing 3f21afda659b54940055f0dfe8913a9923de3c4cc4ccc30d9f2740b90486a3dc
2019/07/29 22:03:27 [INFO] ▶ Analyzing 2de47790f9637f56324ba24ca369b87ff4dc36078223e582083aa6544735687b
2019/07/29 22:03:27 [WARN] ▶ Image [registry-sec:latest] contains 1 total vulnerabilities
2019/07/29 22:03:27 [ERRO] ▶ Image [registry-sec:latest] contains 1 unapproved vulnerabilities
+------------+---------------------+--------------+-----------------+---------------------------------------------------------------+
| STATUS     | CVE SEVERITY        | PACKAGE NAME | PACKAGE VERSION | CVE DESCRIPTION                                               |
+------------+---------------------+--------------+-----------------+---------------------------------------------------------------+
| Unapproved | High CVE-2018-20843 | expat        | 2.2.5-r0        |                                                               |
|            |                     |              |                 | https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20843 |
+------------+---------------------+--------------+-----------------+---------------------------------------------------------------+
```