### PR TITLE
[release/2.7 backport] Fix security issues: bump alpine to 3.11

### DIFF
--- a/Dockerfile.noarch
+++ b/Dockerfile.noarch
@@ -1,9 +1,9 @@
 # Build a minimal distribution container
 
-FROM alpine:3.8
+FROM alpine:3.11
 
 RUN set -ex \
-    && apk add --no-cache ca-certificates apache2-utils
+    && apk add --no-cache ca-certificates
 
 COPY ./registry /bin/registry
 COPY ./config-example.yml /etc/docker/registry/config.yml

--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -1,9 +1,9 @@
 # Build a minimal distribution container
 
-FROM alpine:3.8
+FROM alpine:3.11
 
 RUN set -ex \
-    && apk add --no-cache ca-certificates apache2-utils
+    && apk add --no-cache ca-certificates
 
 COPY ./registry /bin/registry
 COPY ./config-example.yml /etc/docker/registry/config.yml

--- a/arm/Dockerfile
+++ b/arm/Dockerfile
@@ -1,9 +1,9 @@
 # Build a minimal distribution container
 
-FROM alpine:3.8
+FROM alpine:3.11
 
 RUN set -ex \
-    && apk add --no-cache ca-certificates apache2-utils
+    && apk add --no-cache ca-certificates
 
 COPY ./registry /bin/registry
 COPY ./config-example.yml /etc/docker/registry/config.yml

--- a/arm64/Dockerfile
+++ b/arm64/Dockerfile
@@ -1,9 +1,9 @@
 # Build a minimal distribution container
 
-FROM alpine:3.8
+FROM alpine:3.11
 
 RUN set -ex \
-    && apk add --no-cache ca-certificates apache2-utils
+    && apk add --no-cache ca-certificates
 
 COPY ./registry /bin/registry
 COPY ./config-example.yml /etc/docker/registry/config.yml


### PR DESCRIPTION
Backport of https://github.com/docker/distribution-library-image/pull/92 for the release/2.7 branch