### PR TITLE
Change distribution GitHub repo URL

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [ $# -eq 0 ] ; then
-	echo "Usage: ./update.sh <docker/distribution tag or branch>"
+	echo "Usage: ./update.sh <distribution/distribution tag or branch>"
 	exit
 fi
 
@@ -22,7 +22,7 @@ echo "Fetching and building distribution $VERSION..."
 # Create a temporary directory.
 TEMP=`mktemp -d --tmpdir distribution.XXXXXX`
 
-git clone -b $VERSION https://github.com/docker/distribution.git $TEMP
+git clone -b $VERSION https://github.com/distribution/distribution.git $TEMP
 docker build --build-arg GOARCH=$GOARCH --build-arg GOARM=$GOARM -t distribution-builder-$GOARCH $TEMP
 
 # Create a dummy distribution-build container so we can run a cp against it.


### PR DESCRIPTION
`distribution` has been donated to CNCF and moved to a new GH repo. This is a small PR that updates the GitHub repo URL.