### PR TITLE
Fix CVE-2022-28391 by bumping alpine from 3.15 to 3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
- addresses https://github.com/distribution/distribution/issues/3648