### PR TITLE
Add source and description labels to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.19
 
+LABEL org.opencontainers.image.source="https://github.com/distribution/distribution-library-image"
+LABEL org.opencontainers.image.description="A simple container image for running a local container registry"
+
 RUN apk add --no-cache ca-certificates
 
 RUN set -eux; \


### PR DESCRIPTION
### Issue
Partially resolves #161 

### Description
This change adds the source and description (not needed but nice to have) labels needed by GitHub dependabot to update usages of registry container image.

### Additional context
1. https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file?learn=dependency_version_updates&learnProduct=code-security#docker
1. https://github.com/dependabot-fixtures/docker-with-source