### PR TITLE
chore(ci): Update to v3.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,16 @@ RUN apk add --no-cache ca-certificates
 
 RUN set -eux; \
 # https://github.com/distribution/distribution/releases
-	version='3.1.0'; \
+	version='3.1.1'; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		x86_64)  arch='amd64';   sha256='c69f2b8778c5357a77f6b41730d94d5f0b2b7cf54534040a06af5f0a70a731b2' ;; \
-		aarch64) arch='arm64';   sha256='f5527b7ed356767afb8a616e7b9423ef161b470e3674893e395e2a4e656deb1c' ;; \
-		armhf)   arch='armv6';   sha256='2c9a44ea1c289bade76770de459c437dde0bea3b44a3e7555264a63707e71470' ;; \
-		armv7)   arch='armv7';   sha256='0217d5704cd0be893320e686ca6bb7341991d9ed23251ac1265301994a890b6f' ;; \
-		ppc64le) arch='ppc64le'; sha256='1dc0fc28f368dd2d3b485f1bc7f9e5a6cb2421cf8fa94aade30fc334a362ae47' ;; \
-		s390x)   arch='s390x';   sha256='cbe535d6d70e5d9b6c160a6c52445eb9c90af57e12e2b5d377d1263077ae741e' ;; \
-		riscv64) arch='riscv64'; sha256='77cd50cd517758a5de09391d4cbda47e64caf1b67ba07413fbfbfeffed6de444' ;; \
+		x86_64)  arch='amd64';   sha256='6f330a3ba9ea1d23a6ee189f449d792595240585bb2f159123d76ac594f70dd8' ;; \
+		aarch64) arch='arm64';   sha256='8167316d2b4a57e10d44f8c8a3c75fea5f3ec1c71872760bb903e5e8e52e9ad6' ;; \
+		armhf)   arch='armv6';   sha256='8cf93e43dfddb195f46dcf3e643d021f29c689a2662d1edb1e70f536f380e3ba' ;; \
+		armv7)   arch='armv7';   sha256='23bfb562d2b41dc6cb800fc7a2ea682071999ebb4c6e7c8162988bc49eb10ec3' ;; \
+		ppc64le) arch='ppc64le'; sha256='7f7e126b18b3deb1eecf14824bd80215cda6a10bb07a47c7c42268319cf5b305' ;; \
+		s390x)   arch='s390x';   sha256='27f5f3237a6332b129d7383066eee99f15759f9add9304fbf283cef1e3803041' ;; \
+		riscv64) arch='riscv64'; sha256='a64bb17c994885382c977d73695a3f000e884c25b8e5aa14857fedaa096619bb' ;; \
 		*) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
 	esac; \
 	wget -O registry.tar.gz "https://github.com/distribution/distribution/releases/download/v${version}/registry_${version}_linux_${arch}.tar.gz"; \


### PR DESCRIPTION
See: https://github.com/distribution/distribution/releases/tag/v3.1.1

```shell
$ docker run --rm registry:v3.1.1 registry -v
registry github.com/distribution/distribution/v3 3.1.1

# All 7 platforms built successfully, and registry -v reports 3.1.1.

  IMAGE                  ID             DISK USAGE   CONTENT SIZE
  registry:v3.1          bbac8362941d        196MB          133MB
  ├─ linux/amd64         566f1f0d6b81       20.2MB         20.2MB
  ├─ linux/arm/v6        0c5cdebe817a       18.8MB         18.8MB
  ├─ linux/arm/v7        2b1652091b86       18.5MB         18.5MB
  ├─ linux/arm64         1ee3306e14ca       81.8MB         18.9MB
  ├─ linux/ppc64le       7375650b61b2       18.4MB         18.4MB
  ├─ linux/riscv64       1c9ea511bed3       19.2MB         19.2MB
  └─ linux/s390x         24d981f26e7d       19.4MB         19.4MB

  registry github.com/distribution/distribution/v3 3.1.1
```